### PR TITLE
set_cairo_camera_context_path references vmobject

### DIFF
--- a/manimforge/cairo.pyi
+++ b/manimforge/cairo.pyi
@@ -7,7 +7,12 @@ import cairo
 class CairoCamera:
     def __init__(self, *args, **kwargs) -> None: ...
 
-    def set_cairo_context_path(self, ctx: cairo.Context, vmobject: Any, points: npt.NDArray[np.float64]) -> None:
+    def set_cairo_context_path(
+        self,
+        ctx: cairo.Context,
+        vmobject: Any,
+        points: npt.NDArray[np.float64]
+    ) -> None:
         """Traces a VMobject on the :class:`cairo.Context`.
 
         Parameters

--- a/src/cairo.rs
+++ b/src/cairo.rs
@@ -6,24 +6,70 @@ use pyo3::types::{PyTuple, PyDict};
 use std::iter;
 
 /// Check if two points are approximately equal
-fn consider_points_equal_2d(p1: ArrayView1<f64>, p2: ArrayView1<f64>) -> bool {
-    let rtol = 1e-5;
-    let atol = 1e-6; // TODO make this based off vmobject
-    ((p1[0] - p2[0]).abs() <= atol + rtol * p1[0].abs())
-        & ((p1[1] - p2[1]).abs() <= atol + rtol * p1[1].abs())
+/// 
+/// The x and y values of the points are scaled by the relative tolerance and
+/// compared to the absolute tolerance. If the difference between the two
+/// points is less than or equal to the absolute tolerance, then the points are
+/// considered equal.
+/// 
+/// ## Parameters
+/// - `p1`: The first point (x, y)
+/// - `p2`: The second point (x, y)
+/// 
+/// ## Returns
+/// - `bool`: True if the points are approximately equal, False otherwise
+fn consider_points_equal_2d(
+    p1: ArrayView1<f64>,
+    p2: ArrayView1<f64>,
+) -> bool {
+    // relative tolerance
+    let rtol: f64 = 1e-5;
+    // absolute tolerance
+    let atol: f64 = 1e-6; // TODO make this based off vmobject
+    // Use a logical AND instead of a bitwise AND here to encourage
+    // short-circuiting -- That is, don't evaluate the second condition if the
+    // first one is false.
+    ( (p1[0] - p2[0]).abs() <= atol + rtol * p1[0].abs() ) &&
+    ( (p1[1] - p2[1]).abs() <= atol + rtol * p1[1].abs() )
+    // Is there a difference between:
+    // - bool & bool
+    // - !bool & !bool
+    // - bool && bool
 }
 
-
+/// This function creates subpaths by splitting the input points into segments
+/// based on certain conditions.
+/// 
+/// It uses nppcc (number of points per cubic curve, set to 4) and attempts to
+/// find points that should not be considered part of the same segment based on
+/// the consider_points_equal_2d function.
+/// 
+/// The function filters indices based on this condition and keeps segments
+/// where there is a sufficient number of points (nppcc) between splits.
+/// 
+/// Handles all points in the array, but only keeps segments where there are at
+/// least four points between each split.
+/// 
+/// ## Parameters
+/// 
+/// - `points`: A 2D array of points `((x1, y1), (x2, y2), ...)`
+/// 
+/// ## Returns
+/// 
+/// - `Vec<Array2<f64>>`: A vector of 2D arrays of points, each representing a
+///  subpath
 fn gen_subpaths_from_points_2d(
     points: ArrayView2<f64>,
 ) -> Vec<Array2<f64>> {
+    // Number of Points Per Cubic Curve, or
+    // Number of Points Per Continuous Curve?
     let nppcc = 4;
-    let filtered = (nppcc..points.len_of(Axis(0))).step_by(nppcc).filter(|&n| {
-        !consider_points_equal_2d(
+    let filtered = (nppcc..points.len_of(Axis(0)))
+        .step_by(nppcc).filter(|&n| {
+            !consider_points_equal_2d(
             points.index_axis(Axis(0), n - 1),
             points.index_axis(Axis(0), n),
-        )
-    });
+        )});
     let split_indicies: Vec<usize> = iter::once(0)
         .chain(filtered)
         .chain(iter::once(points.len_of(Axis(0))))
@@ -34,7 +80,9 @@ fn gen_subpaths_from_points_2d(
         .zip(split_indicies.iter().skip(1))
         .filter_map(|(&i1, &i2)| {
             if i2 - i1 >= nppcc {
-                let path = points.slice(s![i1..i2, ..]).to_owned();
+                let path = points
+                    .slice(s![i1..i2, ..])
+                    .to_owned();
                 return Some(path);
             }
             None
@@ -42,8 +90,31 @@ fn gen_subpaths_from_points_2d(
         .collect()
 }
 
-fn gen_cubic_bezier_tuples_from_points(points: ArrayView2<f64>) -> Vec<Array2<f64>>
-{
+/// This function segments the points strictly into groups of four (assuming
+/// each group represents a cubic Bézier curve segment).
+/// 
+/// This function ignores point equality conditions and simply slices the
+/// points array into contiguous blocks of four points (nppcc).
+/// 
+/// It adjusts the length of points to be a multiple of 4 by removing any
+/// remainder points that don’t complete a group of four.
+/// 
+/// Trims the array to a multiple of four, potentially discarding points that
+/// would not form a complete Bézier segment.
+/// 
+/// ## Parameters
+/// 
+/// - `points`: A 2D array of points `((x1, y1), (x2, y2), (x3, y3), (x4, y4))`
+/// 
+/// ## Returns
+/// 
+/// - `Vec<Array2<f64>>`: A vector of 2D arrays of points, each representing a
+/// cubic Bézier curve segment
+fn gen_cubic_bezier_tuples_from_points(
+    points: ArrayView2<f64>
+) -> Vec<Array2<f64>> {
+    // Number of Points Per Cubic Curve, or
+    // Number of Points Per Continuous Curve?
     let nppcc = 4;
     let remainder = points.len() % nppcc;
     let points = points.slice(s![..points.len_of(Axis(0)) - remainder, ..]);
@@ -62,7 +133,10 @@ pub struct CairoCamera;
 impl CairoCamera {
     #[new]
     #[pyo3(signature=(*_args, **_kwargs))]
-    fn new(_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>) -> Self {
+    fn new(
+        _args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>
+    ) -> Self {
         Self
     }
 
@@ -70,10 +144,15 @@ impl CairoCamera {
         &self,
         py: Python<'py>,
         ctx: Py<PyAny>,
-        _vmobject: Py<PyAny>,
-        points: PyReadonlyArray2<'py, f64>,
+        vmobject: Py<PyAny>,
+        // old_points: PyReadonlyArray2<'py, f64>,
     ) -> PyResult<()> {
-        let points = points.as_array();
+        // vmobject.points is the same type as `points`
+        let vm_points = vmobject.getattr(py, "points")?;
+        let vm_readonly_array = vm_points.extract::<PyReadonlyArray2<f64>>(py)?;
+        let points = vm_readonly_array.as_array();
+        // let old_points = points.as_array();
+        // assert_eq!(points, old_points);
         // We assume context is correct because serializing it into the Rust binding cairo::Context is too much work
         ctx.call_method0(py, intern!(py, "new_path"))?;
         let subpaths = gen_subpaths_from_points_2d(points);

--- a/test.py
+++ b/test.py
@@ -1,1 +1,49 @@
-from manimforge.cairo import CairoCamera
+# from manimforge.cairo import CairoCamera
+import manimforge
+from manim import *
+
+cairoCamera = manimforge.cairo.CairoCamera()
+
+class MyCamera(Camera):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def set_cairo_context_path(self, ctx, vmobject: VMobject):
+        cairoCamera.set_cairo_context_path(ctx, vmobject)
+
+class MyMovingCamera(MovingCamera, MyCamera):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+class Test(MovingCameraScene):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(
+            camera_class=MyMovingCamera,
+            *args,
+            **kwargs
+        )
+
+    def construct(self) -> None:
+        self.camera.frame.save_state()
+
+        # Create the axes and the curve
+        ax = Axes(x_range=[-1, 10], y_range=[-1, 10])
+        graph = ax.plot(lambda x: np.sin(x), color=BLUE, x_range=[0, 3*PI])
+
+        # Create Dots based on the graph
+        moving_dot = Dot(ax.i2gp(graph.t_min, graph), color=ORANGE)
+        dot_1 = Dot(ax.i2gp(graph.t_min, graph))
+        dot_2 = Dot(ax.i2gp(graph.t_max, graph))
+
+        self.add(ax, graph, dot_1, dot_2, moving_dot)
+        self.play(self.camera.frame.animate.scale(0.5).move_to(moving_dot))
+
+        def update_curve(mob):
+            mob.move_to(moving_dot.get_center())
+
+        self.camera.frame.add_updater(update_curve)
+        self.play(MoveAlongPath(moving_dot, graph, rate_func=linear))
+        self.camera.frame.remove_updater(update_curve)
+
+        self.play(Restore(self.camera.frame))
+


### PR DESCRIPTION
added some docs to the rust code, reformatted set_cairo_camera_context_path so it references the provided VMObject, and modified test.py to utilize the function.

NOTE:
test.py requires manim to be importable